### PR TITLE
Add white highlighting for variables in string interpolation

### DIFF
--- a/themes/JetBrains Rider Dark Theme-color-theme.json
+++ b/themes/JetBrains Rider Dark Theme-color-theme.json
@@ -98,6 +98,15 @@
         "foreground": "#BDC0C9"
       }
     },
+	{
+	  "scope": [
+		"meta.interpolation.cs",
+		"variable.other.readwrite.cs"
+	  ],
+	  "settings": {
+		"foreground": "#BCD0C9"
+	  }
+	},
     {
       "scope": "invalid",
       "settings": {


### PR DESCRIPTION
I love this theme, it is the most accurate clone of the Rider color scheme that I have seen so far for VSCode. The only thing I noticed that was missing was the special syntax highlighting for variables that are present in an interpolated string. I have added it to match the white of most other variables.